### PR TITLE
Improve error message in ListDNSCache() when using Windows before 8/2012

### DIFF
--- a/Seatbelt/Program.cs
+++ b/Seatbelt/Program.cs
@@ -4008,14 +4008,13 @@ namespace Seatbelt
 
         public static void ListDNSCache()
         {
+            Console.WriteLine("\r\n\r\n=== DNS Cache (via WMI) ===\r\n");
+            
             // lists the local DNS cache via WMI (MSFT_DNSClientCache class)
-
             try
             {
                 ManagementObjectSearcher wmiData = new ManagementObjectSearcher(@"root\standardcimv2", "SELECT * FROM MSFT_DNSClientCache");
                 ManagementObjectCollection data = wmiData.Get();
-
-                Console.WriteLine("\r\n\r\n=== DNS Cache (via WMI) ===\r\n");
 
                 foreach (ManagementObject result in data)
                 {
@@ -4023,6 +4022,10 @@ namespace Seatbelt
                     Console.WriteLine("  Name          : {0}", result["Name"]);
                     Console.WriteLine("  Data          : {0}\r\n", result["Data"]);
                 }
+            }
+            catch (ManagementException ex) when (ex.ErrorCode == ManagementStatus.InvalidNamespace)
+            {
+                Console.WriteLine("  [X] 'MSFT_DNSClientCache' WMI class unavailable (minimum supported versions of Windows: 8/2012)", ex.Message);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The 'MSFT_DNSClientCache' WMI class is unavailable on older Windows versions
Cf. https://msdn.microsoft.com/en-us/library/hh872334%28v=vs.85%29.aspx?f=255&MSPPError=-2147217396

I also moved the "=== DNS Cache (via WMI) ===" line, because if an exception occurs, we get the exception printed but without the header and we do not know in which section the problem is.