### PR TITLE
Add handling of PathTooLongException in FindFiles()

### DIFF
--- a/Seatbelt/Program.cs
+++ b/Seatbelt/Program.cs
@@ -1364,6 +1364,7 @@ namespace Seatbelt
                         files.AddRange(FindFiles(directory, pattern));
                 }
                 catch (UnauthorizedAccessException) { }
+                catch (PathTooLongException) { }
             }
 
             return files;


### PR DESCRIPTION
Happens when the generated path (path+pattern) is too long