### PR TITLE
Add Xen to IsVirtualMachine

### DIFF
--- a/Seatbelt/Program.cs
+++ b/Seatbelt/Program.cs
@@ -1539,6 +1539,7 @@ namespace Seatbelt
                         string manufacturer = item["Manufacturer"].ToString().ToLower();
                         if ((manufacturer == "microsoft corporation" && item["Model"].ToString().ToUpperInvariant().Contains("VIRTUAL"))
                             || manufacturer.Contains("vmware")
+                            || manufacturer.Contains("xen")
                             || item["Model"].ToString() == "VirtualBox")
                         {
                             return true;


### PR DESCRIPTION
Simply added a new condition to IsVirtualMachine, so that VMs running on Citrix XenServer are correctly reported as being virtual.