### PR TITLE
fix nullable types + bugs + minor additions

### DIFF
--- a/Seatbelt/Commands/Products/WsusClientCommand.cs
+++ b/Seatbelt/Commands/Products/WsusClientCommand.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Microsoft.Win32;
 
 namespace Seatbelt.Commands
@@ -19,22 +18,27 @@ namespace Seatbelt.Commands
 
         public override IEnumerable<CommandDTOBase?> Execute(string[] args)
         {
-            yield return new WsusClientDTO()
-            {
-                UseWUServer = (ThisRunTime.GetDwordValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU", "UseWUServer") == 1),
-                Server = ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate", "WUServer"),
-                AlternateServer = ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate", "UpdateServiceUrlAlternate"),
-                StatisticsServer = ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate", "WUStatusServer"),
-            };
+            yield return new WsusClientDTO(
+                (ThisRunTime.GetDwordValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU", "UseWUServer") == 1),
+                ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate", "WUServer"),
+                ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate", "UpdateServiceUrlAlternate"),
+                ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate", "WUStatusServer")
+            );
         }
     }
 
     internal class WsusClientDTO : CommandDTOBase
     {
-        public bool UseWUServer { get; set; }
-        public string Server { get; set; }
-        public string AlternateServer { get; set; }
-        public string StatisticsServer { get; set; }
+        public WsusClientDTO(bool? useWuServer, string? server, string? alternateServer, string? statisticsServer)
+        {
+            UseWUServer = useWuServer;
+            Server = server;
+            AlternateServer = alternateServer;
+            StatisticsServer = statisticsServer;    
+        }
+        public bool? UseWUServer { get; set; }
+        public string? Server { get; set; }
+        public string? AlternateServer { get; set; }
+        public string? StatisticsServer { get; set; }
     }
 }
-#nullable enable

--- a/Seatbelt/Commands/Windows/AMSIProvidersCommand.cs
+++ b/Seatbelt/Commands/Windows/AMSIProvidersCommand.cs
@@ -24,16 +24,20 @@ namespace Seatbelt.Commands.Windows
             {
                 var ProviderPath = ThisRunTime.GetStringValue(RegistryHive.LocalMachine, $"SOFTWARE\\Classes\\CLSID\\{provider}\\InprocServer32", "");
 
-                yield return new AMSIProviderDTO()
-                {
-                    GUID = provider,
-                    ProviderPath = ProviderPath
-                };
+                yield return new AMSIProviderDTO(
+                    provider,
+                    ProviderPath
+                );
             }
         }
 
         internal class AMSIProviderDTO : CommandDTOBase
         {
+            public AMSIProviderDTO(string guid, string? providerPath)
+            {
+                GUID = guid;
+                ProviderPath = providerPath;    
+            }
             public string GUID { get; set; }
             public string? ProviderPath { get; set; }
         }

--- a/Seatbelt/Commands/Windows/AuditPoliciesCommand.cs
+++ b/Seatbelt/Commands/Windows/AuditPoliciesCommand.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -217,7 +216,7 @@ namespace Seatbelt.Commands
                 {
                     // Eat it
                 }
-                string[] files = null;
+                string[]? files = null;
                 try
                 {
                     files = Directory.GetFiles(path);
@@ -227,7 +226,9 @@ namespace Seatbelt.Commands
                     // Eat it
                 }
 
-                if (files == null) continue;
+                if(files == null)
+                    continue;
+                ;
                 foreach (var f in files)
                 {
                     yield return f;
@@ -276,4 +277,3 @@ namespace Seatbelt.Commands
         }
     }
 }
-#nullable enable

--- a/Seatbelt/Commands/Windows/DNSCacheCommand.cs
+++ b/Seatbelt/Commands/Windows/DNSCacheCommand.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Management;
 
@@ -21,7 +20,7 @@ namespace Seatbelt.Commands.Windows
 
         public override IEnumerable<CommandDTOBase?> Execute(string[] args)
         {
-            ManagementObjectCollection data = null;
+            ManagementObjectCollection? data = null;
 
             // lists the local DNS cache via WMI (MSFT_DNSClientCache class)
             try
@@ -46,12 +45,11 @@ namespace Seatbelt.Commands.Windows
             foreach (var o in data)
             {
                 var result = (ManagementObject) o;
-                yield return new DNSCacheDTO()
-                {
-                    Entry = result["Entry"],
-                    Name = result["Name"],
-                    Data = result["Data"]
-                };
+                yield return new DNSCacheDTO(
+                    result["Entry"],
+                    result["Name"],
+                    result["Data"]
+                );
             }
 
             data.Dispose();
@@ -60,9 +58,14 @@ namespace Seatbelt.Commands.Windows
 
     internal class DNSCacheDTO : CommandDTOBase
     {
+        public DNSCacheDTO(object entry, object name, object data)
+        {
+            Entry = entry;
+            Name = name;
+            Data = data;
+        }
         public object Entry { get; set; }
         public object Name { get; set; }
         public object Data { get; set; }
     }
 }
-#nullable enable

--- a/Seatbelt/Commands/Windows/EventLogs/ExplicitLogonEvents/ExplicitLogonEventsCommand.cs
+++ b/Seatbelt/Commands/Windows/EventLogs/ExplicitLogonEvents/ExplicitLogonEventsCommand.cs
@@ -63,7 +63,7 @@ namespace Seatbelt.Commands.Windows.EventLogs.ExplicitLogonEvents
                 yield break;
             }
 
-            var query = $@"*[System/EventId={eventId}] and *[System[TimeCreated[@SystemTime >= '{startTime.ToUniversalTime():o}']]] and *[System[TimeCreated[@SystemTime <= '{endTime.ToUniversalTime():o}']]]";
+            var query = $@"*[System/EventID={eventId}] and *[System[TimeCreated[@SystemTime >= '{startTime.ToUniversalTime():o}']]] and *[System[TimeCreated[@SystemTime <= '{endTime.ToUniversalTime():o}']]]";
 
             var eventsQuery = new EventLogQuery("Security", PathType.LogName, query)
             {
@@ -101,7 +101,7 @@ namespace Seatbelt.Commands.Windows.EventLogs.ExplicitLogonEvents
 
                 yield return new ExplicitLogonEventsDTO()
                 {
-                    TimeCreated = eventDetail.TimeCreated,
+                    TimeCreatedUtc = eventDetail.TimeCreated?.ToUniversalTime(),
                     SubjectUser = subjectUserName,
                     SubjectDomain = subjectDomainName,
                     TargetUser = targetUserName,

--- a/Seatbelt/Commands/Windows/EventLogs/ExplicitLogonEvents/ExplicitLogonEventsCommandDTO.cs
+++ b/Seatbelt/Commands/Windows/EventLogs/ExplicitLogonEvents/ExplicitLogonEventsCommandDTO.cs
@@ -11,7 +11,7 @@ namespace Seatbelt.Commands.Windows.EventLogs.ExplicitLogonEvents
         public string TargetDomain { get; set; }
         public string Process { get; set; }
         public string IpAddress { get; set; }
-        public DateTime? TimeCreated { get; set; }
+        public DateTime? TimeCreatedUtc { get; set; }
     }
 }
 #nullable enable

--- a/Seatbelt/Commands/Windows/EventLogs/ExplicitLogonEvents/ExplicitLogonEventsTextFormatter.cs
+++ b/Seatbelt/Commands/Windows/EventLogs/ExplicitLogonEvents/ExplicitLogonEventsTextFormatter.cs
@@ -21,7 +21,7 @@ namespace Seatbelt.Commands.Windows.EventLogs.ExplicitLogonEvents
             var subjectUser = dto.SubjectDomain + "\\" + dto.SubjectUser;
             var uniqueCredKey = $"{targetUser},{dto.Process},{subjectUser},{dto.IpAddress}";
 
-            WriteLine($"{dto.TimeCreated?.ToString("MM/dd/yyyy hh:mm tt")},{uniqueCredKey}");
+            WriteLine($"{dto.TimeCreatedUtc?.ToLocalTime().ToString("MM/dd/yyyy hh:mm tt")},{uniqueCredKey}");
 
             //if (events.TryGetValue(uniqueCredKey, out _) == false)
             //{

--- a/Seatbelt/Commands/Windows/EventLogs/ProcessCreationEventsCommand.cs
+++ b/Seatbelt/Commands/Windows/EventLogs/ProcessCreationEventsCommand.cs
@@ -1,8 +1,9 @@
-﻿#nullable disable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.Eventing.Reader;
 using System.Text.RegularExpressions;
+using Seatbelt.Output.Formatters;
+using Seatbelt.Output.TextWriters;
 using Seatbelt.Util;
 
 
@@ -27,7 +28,8 @@ namespace Seatbelt.Commands.Windows.EventLogs
                 yield break;
             }
 
-            WriteVerbose($"Searching process creation logs (EID 4688) for sensitive data.\n");
+            WriteVerbose($"Searching process creation logs (EID 4688) for sensitive data.");
+            WriteVerbose($"Format: Date(Local time),User,Command line.\n");
 
             // Get our "sensitive" cmdline regexes from a common helper function.
             Regex[] processCmdLineRegex = MiscUtil.GetProcessCmdLineRegex();
@@ -39,35 +41,53 @@ namespace Seatbelt.Commands.Windows.EventLogs
             for (var eventDetail = logReader.ReadEvent(); eventDetail != null; eventDetail = logReader.ReadEvent())
             {
 
+                var user = eventDetail.Properties[1].Value.ToString().Trim();
                 var commandLine = eventDetail.Properties[8].Value.ToString().Trim();
-                
-                if (commandLine != "")
+
+                foreach (var reg in processCmdLineRegex)
                 {
-                    foreach (var reg in processCmdLineRegex)
+                    var m = reg.Match(commandLine);
+                    if (m.Success)
                     {
-                        var m = reg.Match(commandLine);
-                        if (m.Success)
-                        {
-                            yield return new ProcessCreationDTO()
-                            {
-                                TimeCreated = eventDetail.TimeCreated,
-                                EventID = eventDetail.Id,
-                                UserID = $"{eventDetail.UserId}",
-                                Match = m.Value
-                            };
-                        }
+                        yield return new ProcessCreationEventDTO(
+                            eventDetail.TimeCreated?.ToUniversalTime(),
+                            eventDetail.Id,
+                            user,
+                            commandLine
+                        );
                     }
                 }
             }
         }
     }
 
-    internal class ProcessCreationDTO : CommandDTOBase
+    internal class ProcessCreationEventDTO : CommandDTOBase
     {
-        public DateTime? TimeCreated { get; set; }
+        public ProcessCreationEventDTO(DateTime? timeCreatedUtc, int eventId, string user, string match)
+        {
+            TimeCreatedUtc = timeCreatedUtc;
+            EventID = eventId;
+            User = user;
+            Match = match;
+        }
+        public DateTime? TimeCreatedUtc { get; set; }
         public int EventID { get; set; }
-        public string UserID { get; set; }
+        public string User { get; set; }
         public string Match { get; set; }
     }
+
+    [CommandOutputType(typeof(ProcessCreationEventDTO))]
+    internal class ProcessCreationEventTextFormatter : TextFormatterBase
+    {
+        public ProcessCreationEventTextFormatter(ITextWriter writer) : base(writer)
+        {
+        }
+
+        public override void FormatResult(CommandBase? command, CommandDTOBase result, bool filterResults)
+        {
+            var dto = (ProcessCreationEventDTO)result;
+
+            WriteLine($"  {dto.TimeCreatedUtc?.ToLocalTime(),-22}  {dto.User,-30} {dto.Match}");
+        }
+    }
 }
-#nullable enable

--- a/Seatbelt/Commands/Windows/ScheduledTasksCommand.cs
+++ b/Seatbelt/Commands/Windows/ScheduledTasksCommand.cs
@@ -105,7 +105,7 @@ namespace Seatbelt.Commands.Windows
 
                 if (Runtime.FilterResults)
                 {
-                    if (String.IsNullOrEmpty($"{result["Author"]}") || Regex.IsMatch($"{result["Author"]}", "Microsoft"))
+                    if (Regex.IsMatch($"{result["Author"]}", "Microsoft"))
                     {
                         continue;
                     }

--- a/Seatbelt/Commands/Windows/TokenGroupCommand.cs
+++ b/Seatbelt/Commands/Windows/TokenGroupCommand.cs
@@ -1,5 +1,4 @@
-﻿#nullable disable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Security.Principal;
 using Seatbelt.Output.Formatters;
 using Seatbelt.Output.TextWriters;
@@ -34,17 +33,22 @@ namespace Seatbelt.Commands.Windows
                 }
                 catch { }
 
-                yield return new TokenGroupsDTO()
-                {
-                    GroupSID = $"{(SecurityIdentifier)group}",
-                    GroupName = groupName
-                };
+                yield return new TokenGroupsDTO(
+                    $"{(SecurityIdentifier)group}",
+                    groupName
+                );
             }
         }
     }
 
     internal class TokenGroupsDTO : CommandDTOBase
     {
+        public TokenGroupsDTO(string groupSid, string groupName)
+        {
+            GroupSID = groupSid;
+            GroupName = groupName;  
+        }
+
         //public System.Security.Principal.SecurityIdentifier GroupSID { get; set; }
         public string GroupSID { get; set; }
         public string GroupName { get; set; }
@@ -65,4 +69,3 @@ namespace Seatbelt.Commands.Windows
         }
     }
 }
-#nullable enable

--- a/Seatbelt/Runtime.cs
+++ b/Seatbelt/Runtime.cs
@@ -202,10 +202,14 @@ namespace Seatbelt
 
                 var instance = (CommandBase)Activator.CreateInstance(type, new object[] { this });
 
+#if DEBUG
                 if (instance.Command != "TEMPLATE")
                 {
                     AllCommands.Add(instance);
                 }
+#else
+                AllCommands.Add(instance);
+#endif
             }
 
             AllCommands = AllCommands.OrderBy(c => c.Command).ToList();


### PR DESCRIPTION
- Fixed logonevents/explicitlogonevents/poweredonevents filter
- Fixed nullable types in osinfo, processcreationevents, and logoninfo
- Added InputLanguage and InstalledInputLanguages to osinfo
- Fixed uptime bugs in osinfo
- Transitioned to UTC in osinfo and showing both in output
- Transitioned several other commands to UTC
- Fixed processcreationevents not pulling the correct username
- Prettified the output of processcreationevents
- Ignore virtual machine logons in logonevents