### PR TITLE
Added improved code for managed assembly detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,5 +445,6 @@ Seatbelt incorporates various collection items, code C# snippets, and bits of Po
 * Mark McKinnon's post on [decoding the DateCreated and DateLastConnected SSID values](http://cfed-ttf.blogspot.com/2009/08/decoding-datecreated-and.html)
 * This Specops [post on group policy caching](https://specopssoft.com/blog/things-work-group-policy-caching/)
 * sa_ddam213's StackOverflow post on [enumerating items in the Recycle Bin](https://stackoverflow.com/questions/18071412/list-filenames-in-the-recyclebin-with-c-sharp-without-using-any-external-files)
+* Kirill Osenkov's [code for managed assembly detection](https://stackoverflow.com/a/15608028)
 
 We've tried to do our due diligence for citations, but if we've left someone/something out, please let us know!

--- a/Seatbelt/Util/FileUtil.cs
+++ b/Seatbelt/Util/FileUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -8,25 +9,75 @@ namespace Seatbelt.Util
 {
     class FileUtil
     {
-        public static bool IsDotNetAssembly(string path)
+        public static bool IsDotNetAssembly(string fileName)
         {
             try
             {
-                var myAssemblyName = AssemblyName.GetAssemblyName(path);
-                return true;
-            }
-            catch (BadImageFormatException exception)
-            {
-                if (Regex.IsMatch(exception.Message, ".*This assembly is built by a runtime newer than the currently loaded runtime and cannot be loaded.*", RegexOptions.IgnoreCase))
+                // from https://stackoverflow.com/a/15608028
+                using (Stream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read))
+                using (BinaryReader binaryReader = new BinaryReader(fileStream))
                 {
+                    if (fileStream.Length < 64)
+                    {
+                        return false;
+                    }
+
+                    //PE Header starts @ 0x3C (60). Its a 4 byte header.
+                    fileStream.Position = 0x3C;
+                    uint peHeaderPointer = binaryReader.ReadUInt32();
+                    if (peHeaderPointer == 0)
+                    {
+                        peHeaderPointer = 0x80;
+                    }
+
+                    // Ensure there is at least enough room for the following structures:
+                    //     24 byte PE Signature & Header
+                    //     28 byte Standard Fields         (24 bytes for PE32+)
+                    //     68 byte NT Fields               (88 bytes for PE32+)
+                    // >= 128 byte Data Dictionary Table
+                    if (peHeaderPointer > fileStream.Length - 256)
+                    {
+                        return false;
+                    }
+
+                    // Check the PE signature.  Should equal 'PE\0\0'.
+                    fileStream.Position = peHeaderPointer;
+                    uint peHeaderSignature = binaryReader.ReadUInt32();
+                    if (peHeaderSignature != 0x00004550)
+                    {
+                        return false;
+                    }
+
+                    // skip over the PEHeader fields
+                    fileStream.Position += 20;
+
+                    const ushort PE32 = 0x10b;
+                    const ushort PE32Plus = 0x20b;
+
+                    // Read PE magic number from Standard Fields to determine format.
+                    var peFormat = binaryReader.ReadUInt16();
+                    if (peFormat != PE32 && peFormat != PE32Plus)
+                    {
+                        return false;
+                    }
+
+                    // Read the 15th Data Dictionary RVA field which contains the CLI header RVA.
+                    // When this is non-zero then the file contains CLI data otherwise not.
+                    ushort dataDictionaryStart = (ushort)(peHeaderPointer + (peFormat == PE32 ? 232 : 248));
+                    fileStream.Position = dataDictionaryStart;
+
+                    uint cliHeaderRva = binaryReader.ReadUInt32();
+                    if (cliHeaderRva == 0)
+                    {
+                        return false;
+                    }
+
                     return true;
                 }
             }
-            catch
-            {
+            catch {
+                return false;
             }
-
-            return false;
         }
     }
 


### PR DESCRIPTION
-IsDotNetAssembly() should no longer cause image load events.