### PR TITLE
Added PowerShellHistory command to read PowerShell console history fr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Seatbelt is licensed under the BSD 3-Clause license.
           PoweredOnEvents        - Reboot and sleep schedule based on the System event log EIDs 1, 12, 13, 42, and 6008. Default of 7 days, argument == last X days.
         + PowerShell             - PowerShell versions and security settings
           PowerShellEvents       - PowerShell script block logs (4104) with sensitive data.
+          PowerShellHistory      - Iterates through every local user and attempts to read their PowerShell console history if successful will print it.
           Printers               - Installed Printers (via WMI)
           ProcessCreationEvents  - Process creation logs (4688) with sensitive data.
           Processes              - Running processes with file info company names that don't contain 'Microsoft', "-full" enumerates all processes
@@ -154,7 +155,7 @@ Seatbelt is licensed under the BSD 3-Clause license.
             ChromePresence, CloudCredentials, CredEnum, dir, DpapiMasterKeys,
             ExplorerMRUs, ExplorerRunCommands, FirefoxPresence, IdleTime,
             IEFavorites, IETabs, IEUrls, MappedDrives,
-            OfficeMRUs, PuttyHostKeys, PuttySessions, RDCManFiles,
+            OfficeMRUs, PowerShellHistory, PuttyHostKeys, PuttySessions, RDCManFiles,
             RDPSavedConnections, SlackDownloads, SlackPresence, SlackWorkspaces,
             TokenGroups, WindowsCredentialFiles, WindowsVault
 
@@ -192,7 +193,7 @@ Seatbelt is licensed under the BSD 3-Clause license.
 
        "Seatbelt.exe -group=misc" runs the following commands:
 
-            ChromeBookmarks, ChromeHistory, ExplicitLogonEvents, FileInfo, FirefoxHistory, HuntLolbas
+            ChromeBookmarks, ChromeHistory, ExplicitLogonEvents, FileInfo, FirefoxHistory, HuntLolbas,
             InstalledProducts, InterestingFiles, LogonEvents, OutlookDownloads,
             PowerShellEvents, ProcessCreationEvents, ProcessOwners, RecycleBin,
             reg, RPCMappedEndpoints, ScheduledTasks, SearchIndex,
@@ -301,6 +302,7 @@ Executed with: `Seatbelt.exe -group=user`
 | IEUrls| Internet Explorer typed URLs (last 7 days, argument == last X days) |
 | MappedDrives | Users' mapped drives (via WMI) |
 | OfficeMRUs | Office most recently used file list (last 7 days) |
+|PowerShellHistory | Iterates through every local user and attempts to read their PowerShell console history if successful will print it  |
 | PuttyHostKeys | Saved Putty SSH host keys |
 | PuttySessions | Saved Putty configuration (interesting fields) and SSH host keys |
 | RDCManFiles | Windows Remote Desktop Connection Manager settings files |

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Executed with: `Seatbelt.exe -group=user`
 | IEUrls| Internet Explorer typed URLs (last 7 days, argument == last X days) |
 | MappedDrives | Users' mapped drives (via WMI) |
 | OfficeMRUs | Office most recently used file list (last 7 days) |
-|PowerShellHistory | Iterates through every local user and attempts to read their PowerShell console history if successful will print it  |
+| PowerShellHistory | Iterates through every local user and attempts to read their PowerShell console history if successful will print it  |
 | PuttyHostKeys | Saved Putty SSH host keys |
 | PuttySessions | Saved Putty configuration (interesting fields) and SSH host keys |
 | RDCManFiles | Windows Remote Desktop Connection Manager settings files |

--- a/Seatbelt/Commands/Windows/PowerShellHistory.cs
+++ b/Seatbelt/Commands/Windows/PowerShellHistory.cs
@@ -1,0 +1,99 @@
+﻿#nullable disable
+using static Seatbelt.Interop.Netapi32;
+using System.Collections.Generic;
+using Seatbelt.Output.TextWriters;
+using Seatbelt.Output.Formatters;
+
+namespace Seatbelt.Commands.Windows
+{
+    internal class PowerShellHistoryCommand : CommandBase
+    { 
+
+        public override string Command => "PowerShellHistory";
+        public override string Description => "Iterates through every local user and attempts to read their PowerShell console history if successful will print it.";
+        public override CommandGroup[] Group => new[] { CommandGroup.User };
+        public override bool SupportRemote => false;
+        public Runtime ThisRunTime;
+
+        public PowerShellHistoryCommand(Runtime runtime) : base(runtime)
+        {
+            ThisRunTime = runtime;
+        }
+
+        public override IEnumerable<CommandDTOBase?> Execute(string[] args)
+        {
+            string computerName = ThisRunTime.ComputerName;
+
+            // An alternative approach to obtaining local users if you do not want to use P/Invoke and system is using AD
+            // https://stackoverflow.com/questions/8191696/list-all-local-users-using-directory-service
+
+            foreach (var localUser in GetLocalUsers(computerName))
+            {
+                // Loop through each local user and attempt to read their consolehost history
+                // This is enabled by default starting with PowerShell v5 on Windows 10
+                // Does not record terminal less PowerShell sessions
+
+                string Errored = "";
+                string user = localUser.name;
+                string content = "";
+                try
+                {
+                    string path = $"C:\\Users\\{user}\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadline\\ConsoleHost_history.txt";
+                    if (System.IO.File.Exists(path))
+                    {
+                        // Make sure file exists before attempting to read it
+                        content += System.IO.File.ReadAllText(path);
+                    }
+                    else
+                    {
+                        Errored = "ConsoleHost_History.txt was not found";
+                    }
+                }
+                catch(System.Exception e)
+                {
+                    Errored = e.Message;
+                }
+
+                if (Errored.Length > 0)
+                {
+                    yield return new PowerShellHistoryDTO() { User = user, Error = Errored };
+                }
+                else 
+                {
+                    yield return new PowerShellHistoryDTO() { User = user, Content = content };
+                }
+            }
+        }
+
+        internal class PowerShellHistoryDTO : CommandDTOBase
+        {
+            public string? User { get; set; }
+            public string? Content { get; set; }
+            public string? Error { get; set; } = "";
+        }
+        
+        [CommandOutputType(typeof(PowerShellHistoryDTO))]
+        internal class PowerShellHistoryFormatter : TextFormatterBase
+        {
+            public PowerShellHistoryFormatter(ITextWriter writer) : base(writer)
+            {
+            }
+
+            public override void FormatResult(CommandBase? command, CommandDTOBase result, bool filterResults)
+            {
+                var dto = (PowerShellHistoryDTO)result;
+                if (dto.Error.Length > 0)
+                {
+                    WriteLine($"An error has occurred when attempting to read the history of local user: {dto.User} error: {dto.Error}.");
+                }
+                else
+                {
+                    WriteLine($"PowerShell Console History for local user: {dto.User}: \n");
+                    WriteLine(dto.Content);
+                }
+            }
+
+        }
+    }
+}
+#nullable enable

--- a/Seatbelt/Seatbelt.csproj
+++ b/Seatbelt/Seatbelt.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Commands\Misc\HuntLOLBAS.cs" />
     <Compile Include="Commands\Windows\HotfixesCommand.cs" />
     <Compile Include="Commands\Windows\MicrosoftUpdatesCommand.cs" />
+    <Compile Include="Commands\Windows\PowerShellHistory.cs" />
     <Compile Include="SeatbeltArgumentParser.cs" />
     <Compile Include="Commands\Browser\ChromeBookmarksCommand.cs" />
     <Compile Include="Commands\Browser\ChromeHistoryCommand.cs" />


### PR DESCRIPTION
…om local users. Also fixed a missing comma in the README. 

Example Usage (replaced "John." with "John:"):

![image](https://user-images.githubusercontent.com/36310667/90579115-034c5e00-e193-11ea-896b-987d72b89f50.png)

Thanks for making the codebase really modular it's a joy to add new modules. 