### PR TITLE
McAfeeSiteList: fix null pointer exception on invalid sites

### DIFF
--- a/Seatbelt/Commands/Products/McAfeeSiteListCommand.cs
+++ b/Seatbelt/Commands/Products/McAfeeSiteListCommand.cs
@@ -120,7 +120,10 @@ namespace Seatbelt.Commands
 
                     foreach (XmlNode site in sites[0].ChildNodes)
                     {
-
+                        if (site.Attributes["Name"] == null || site.Attributes["Server"] == null)
+                        {
+                            continue;
+                        }
                         var type = site.Name;
                         var name = site.Attributes["Name"].Value;
                         var server = site.Attributes["Server"].Value;


### PR DESCRIPTION
One common example is <ProxyConfigList UseIEConfig="0"/>

Example on: https://community.mcafee.com/t5/ePolicy-Orchestrator-ePO/EPO-Dashboard-Report-Did-not-report-results/td-p/376167