### PR TITLE
Fix OS version number collection on Windows 10

### DIFF
--- a/Seatbelt/Commands/Windows/DotNetCommand.cs
+++ b/Seatbelt/Commands/Windows/DotNetCommand.cs
@@ -4,7 +4,7 @@ using Seatbelt.Output.TextWriters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Management;
 
 namespace Seatbelt.Commands.Windows
 {
@@ -38,6 +38,20 @@ namespace Seatbelt.Commands.Windows
             return versions;
         }
 
+        public static string GetOSVersion()
+        {
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher("SELECT Version FROM Win32_OperatingSystem");
+            try
+            {
+                foreach (var os in searcher.Get())
+                {
+                    return os["Version"].ToString();
+                }
+            }
+            catch { }
+
+            return "";
+        }
 
         public override IEnumerable<CommandDTOBase?> Execute(string[] args)
         {
@@ -58,11 +72,12 @@ namespace Seatbelt.Commands.Windows
                 installedDotNetVersions.Add(dotNet4Version);
             }
 
+            int osVersionMajor = int.Parse(GetOSVersion().Split('.')[0]);
 #nullable restore
             yield return new DotNetDTO(
                 installedCLRVersions.ToArray(),
                 installedDotNetVersions.ToArray(),
-                Environment.OSVersion.Version.Major >= 10
+                osVersionMajor >= 10
                 );
         }
     }


### PR DESCRIPTION
Due to lack of manifest, `Environment.OSVersion.Version.Major` returns `8` even on Windows 10!

Cf. https://stackoverflow.com/questions/31520192/windows-10-rtm-osversion-not-returning-what-i-expect
https://docs.microsoft.com/en-us/windows/win32/sysinfo/targeting-your-application-at-windows-8-1