### PR TITLE
Decimal point problem solving

### DIFF
--- a/Seatbelt/Commands/Products/OfficeMRUsCommand.cs
+++ b/Seatbelt/Commands/Products/OfficeMRUsCommand.cs
@@ -75,10 +75,10 @@ namespace Seatbelt.Commands.Windows
                 {
                     userName = sid;
                 }
-
-                var officeVersion =
+                
+                var officeVersion = 
                     RegistryUtil.GetSubkeyNames(RegistryHive.Users, $"{sid}\\Software\\Microsoft\\Office")
-                    ?.Where(k => float.TryParse(k, out _));
+                    ?.Where(k => float.TryParse(k, NumberStyles.AllowDecimalPoint, new CultureInfo("en-GB"), out _));
 
                 if (officeVersion is null)
                     continue;

--- a/Seatbelt/Commands/Windows/WindowsVaultCommand.cs
+++ b/Seatbelt/Commands/Windows/WindowsVaultCommand.cs
@@ -54,6 +54,10 @@ namespace Seatbelt.Commands.Windows
             var vaultGuidPtr = IntPtr.Zero;
             var result = VaultEnumerateVaults(0, ref vaultCount, ref vaultGuidPtr);
 
+            var vaultItemType = Environment.OSVersion.Version > new Version("6.2") ?
+                typeof(VAULT_ITEM_WIN8) :
+                typeof(VAULT_ITEM_WIN7);
+
             if (result != 0)
             {
                 WriteError($"Unable to enumerate vaults. Error code: {result}");
@@ -108,7 +112,7 @@ namespace Seatbelt.Commands.Windows
 
                         entries.Add(entry);
 
-                        currentVaultItem = (IntPtr)(currentVaultItem.ToInt64() + Marshal.SizeOf(currentVaultItem));
+                        currentVaultItem = (IntPtr)(currentVaultItem.ToInt64() + Marshal.SizeOf(/*currentVaultItem*/vaultItemType));
                     }
                 }
 

--- a/Seatbelt/Commands/Windows/WindowsVaultCommand.cs
+++ b/Seatbelt/Commands/Windows/WindowsVaultCommand.cs
@@ -112,7 +112,7 @@ namespace Seatbelt.Commands.Windows
 
                         entries.Add(entry);
 
-                        currentVaultItem = (IntPtr)(currentVaultItem.ToInt64() + Marshal.SizeOf(/*currentVaultItem*/vaultItemType));
+                        currentVaultItem = (IntPtr)(currentVaultItem.ToInt64() + Marshal.SizeOf(vaultItemType));
                     }
                 }
 


### PR DESCRIPTION
When we try  parse Office version as float we must use settings, that handle dots sa sepatator integer and fractional part.
That means that old code works correctly only on PCs where its default Culture Style properties handle dot as separator.
![2020-11-21_17-01-21](https://user-images.githubusercontent.com/3364155/99879335-7267a180-2c1d-11eb-95da-3b37be4c3dcb.gif)
