### PR TITLE
Fix Error CS8618 On .NET >= 4.7

### DIFF
--- a/Seatbelt/Commands/Products/SlackDownloadsCommand.cs
+++ b/Seatbelt/Commands/Products/SlackDownloadsCommand.cs
@@ -11,9 +11,9 @@ namespace Seatbelt.Commands
 {
     class Download
     {
-        public string TeamID { get; set; }
-        public string UserID { get; set; }
-        public string DownloadPath { get; set; }
+        public string? TeamID { get; set; }
+        public string? UserID { get; set; }
+        public string? DownloadPath { get; set; }
         public DateTime StartTime { get; set; }
     }
 

--- a/Seatbelt/Commands/Windows/WindowsAutoLogonCommand.cs
+++ b/Seatbelt/Commands/Windows/WindowsAutoLogonCommand.cs
@@ -43,7 +43,7 @@ namespace Seatbelt.Commands.Windows
 
         internal class WindowsAutoLogonDTO : CommandDTOBase
         {
-            public WindowsAutoLogonDTO(string defaultDomainName, string defaultUserName, string defaultPassword, string altDefaultDomainName, string altDefaultUserName, string altDefaultPassword)
+            public WindowsAutoLogonDTO(string? defaultDomainName, string? defaultUserName, string? defaultPassword, string? altDefaultDomainName, string? altDefaultUserName, string? altDefaultPassword)
             {
                 DefaultDomainName = defaultDomainName;
                 DefaultUserName = defaultUserName;
@@ -52,12 +52,12 @@ namespace Seatbelt.Commands.Windows
                 AltDefaultUserName = altDefaultUserName;
                 AltDefaultPassword = altDefaultPassword;    
             }
-            public string DefaultDomainName { get; }
-            public string DefaultUserName { get; }
-            public string DefaultPassword { get; }
-            public string AltDefaultDomainName { get; }
-            public string AltDefaultUserName { get; }
-            public string AltDefaultPassword { get; }
+            public string? DefaultDomainName { get; }
+            public string? DefaultUserName { get; }
+            public string? DefaultPassword { get; }
+            public string? AltDefaultDomainName { get; }
+            public string? AltDefaultUserName { get; }
+            public string? AltDefaultPassword { get; }
         }
     }
 }


### PR DESCRIPTION
When Building with .NET >= 4.7, the error CS8618 appears. This commit fixes it by explicitly setting nullability of some variables.