### PR TITLE
Enumerate Directory Security Descriptors with fileinfo

### DIFF
--- a/Seatbelt/Commands/Misc/FileInfoCommand.cs
+++ b/Seatbelt/Commands/Misc/FileInfoCommand.cs
@@ -56,55 +56,87 @@ namespace Seatbelt.Commands.Windows
 
             foreach (var file in args)
             {
-                FileVersionInfo versionInfo;
-                FileInfo fileInfo;
-                FileSecurity security;
-
-                try
+                if ((File.GetAttributes(file) & FileAttributes.Directory) != FileAttributes.Directory) // If file is not a directory
                 {
-                    versionInfo = FileVersionInfo.GetVersionInfo(file);
-                    fileInfo = new FileInfo(file);
-                    security = File.GetAccessControl(file);
+                    FileVersionInfo versionInfo;
+                    FileInfo fileInfo;
+                    FileSecurity security;
+
+                    try
+                    {
+                        versionInfo = FileVersionInfo.GetVersionInfo(file);
+                        fileInfo = new FileInfo(file);
+                        security = File.GetAccessControl(file);
+                    }
+                    catch
+                    {
+                        // TODO: Properly process error
+                        WriteError($"  [!] Error accessing {file}\n");
+                        continue;
+                    }
+
+                    if (versionInfo != null && fileInfo != null && security != null)  // TODO: Account for cases when any of these aren't null 
+                    {
+                        var isDotNet = FileUtil.IsDotNetAssembly(file);
+
+                        yield return new FileInfoDTO(
+                            versionInfo.Comments,
+                            versionInfo.CompanyName,
+                            versionInfo.FileDescription,
+                            versionInfo.FileName,
+                            versionInfo.FileVersion,
+                            versionInfo.InternalName,
+                            versionInfo.IsDebug,
+                            isDotNet,
+                            versionInfo.IsPatched,
+                            versionInfo.IsPreRelease,
+                            versionInfo.IsPrivateBuild,
+                            versionInfo.IsSpecialBuild,
+                            versionInfo.Language,
+                            versionInfo.LegalCopyright,
+                            versionInfo.LegalTrademarks,
+                            versionInfo.OriginalFilename,
+                            versionInfo.PrivateBuild,
+                            versionInfo.ProductName,
+                            versionInfo.ProductVersion,
+                            versionInfo.SpecialBuild,
+                            fileInfo.Attributes,
+                            fileInfo.CreationTimeUtc,
+                            fileInfo.LastAccessTimeUtc,
+                            fileInfo.LastWriteTimeUtc,
+                            fileInfo.Length,
+                            security.GetSecurityDescriptorSddlForm(AccessControlSections.Access | AccessControlSections.Owner)
+                        );
+                    }
                 }
-                catch
-                {
-                    // TODO: Properly process error
-                    WriteError($"  [!] Error accessing {file}\n");
-                    continue;
-                }
 
-                if (versionInfo != null && fileInfo != null && security != null)  // TODO: Account for cases when any of these aren't null 
+                else // Target is a directory
                 {
-                    var isDotNet = FileUtil.IsDotNetAssembly(file);
+                    DirectorySecurity directorySecurity;
 
-                    yield return new FileInfoDTO(
-                        versionInfo.Comments,
-                        versionInfo.CompanyName,
-                        versionInfo.FileDescription,
-                        versionInfo.FileName,
-                        versionInfo.FileVersion,
-                        versionInfo.InternalName,
-                        versionInfo.IsDebug,
-                        isDotNet,
-                        versionInfo.IsPatched,
-                        versionInfo.IsPreRelease,
-                        versionInfo.IsPrivateBuild,
-                        versionInfo.IsSpecialBuild,
-                        versionInfo.Language,
-                        versionInfo.LegalCopyright,
-                        versionInfo.LegalTrademarks,
-                        versionInfo.OriginalFilename,
-                        versionInfo.PrivateBuild,
-                        versionInfo.ProductName,
-                        versionInfo.ProductVersion,
-                        versionInfo.SpecialBuild,
-                        fileInfo.Attributes,
-                        fileInfo.CreationTimeUtc,
-                        fileInfo.LastAccessTimeUtc,
-                        fileInfo.LastWriteTimeUtc,
-                        fileInfo.Length,
-                        security.GetSecurityDescriptorSddlForm(AccessControlSections.Access | AccessControlSections.Owner)
-                    );
+                    try
+                    {
+                        DirectoryInfo directoryInfo = new DirectoryInfo(file);
+                        directorySecurity = directoryInfo.GetAccessControl();
+                    }
+                    catch
+                    {
+                        // TODO: Properly process error
+                        WriteError($"  [!] Error accessing {file}\n");
+                        continue;
+                    }
+
+                    if (directorySecurity != null)  // TODO: Account for cases when any of these aren't null 
+                    {
+
+                        yield return new DirectoryInfoDTO(
+                            FileAttributes.Directory,
+                            Directory.GetCreationTimeUtc(file),
+                            Directory.GetLastAccessTimeUtc(file),
+                            Directory.GetLastWriteTimeUtc(file),
+                            directorySecurity.GetSecurityDescriptorSddlForm(AccessControlSections.Access | AccessControlSections.Owner)
+                        );
+                    }
                 }
             }
         }
@@ -141,6 +173,7 @@ namespace Seatbelt.Commands.Windows
             Length = length;
             SDDL = sddl;
         }
+
         public string Comments { get; }
         public string CompanyName { get; }
         public string FileDescription { get; }
@@ -166,6 +199,24 @@ namespace Seatbelt.Commands.Windows
         public DateTime LastAccessTimeUtc { get; }
         public DateTime LastWriteTimeUtc { get; }
         public long Length { get; }
+        public string SDDL { get; }
+}
+
+    internal class DirectoryInfoDTO : CommandDTOBase
+    {
+        public DirectoryInfoDTO(FileAttributes attributes, DateTime creationTimeUtc, DateTime lastAccessTimeUtc, DateTime lastWriteTimeUtc, string sddl)
+        {
+            Attributes = attributes;
+            CreationTimeUtc = creationTimeUtc;
+            LastAccessTimeUtc = lastAccessTimeUtc;
+            LastWriteTimeUtc = lastWriteTimeUtc;
+            SDDL = sddl;
+        }
+
+        public FileAttributes Attributes { get; }
+        public DateTime CreationTimeUtc { get; }
+        public DateTime LastAccessTimeUtc { get; }
+        public DateTime LastWriteTimeUtc { get; }
         public string SDDL { get; }
     }
 }

--- a/Seatbelt/Commands/Misc/FileInfoCommand.cs
+++ b/Seatbelt/Commands/Misc/FileInfoCommand.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Security;
 using System.Security.AccessControl;
 
 namespace Seatbelt.Commands.Windows
@@ -56,7 +57,7 @@ namespace Seatbelt.Commands.Windows
 
             foreach (var file in args)
             {
-                if ((File.GetAttributes(file) & FileAttributes.Directory) != FileAttributes.Directory) // If file is not a directory
+                if (File.Exists(file) && (File.GetAttributes(file) & FileAttributes.Directory) != FileAttributes.Directory) // If file is not a directory
                 {
                     FileVersionInfo versionInfo;
                     FileInfo fileInfo;
@@ -68,10 +69,24 @@ namespace Seatbelt.Commands.Windows
                         fileInfo = new FileInfo(file);
                         security = File.GetAccessControl(file);
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Properly process error
-                        WriteError($"  [!] Error accessing {file}\n");
+                        if (ex is FileNotFoundException || ex is SystemException)
+                        {
+                            WriteError($"  [!] Could not locate {file}\n");
+                        }
+                        else if (ex is SecurityException || ex is UnauthorizedAccessException)
+                        {
+                            WriteError($"  [!] Insufficient privileges to access {file}\n");
+                        }
+                        else if (ex is ArgumentException || ex is NotSupportedException || ex is PathTooLongException)
+                        {
+                            WriteError($"  [!] Path \"{file}\" is an invalid format\n");
+                        }
+                        else
+                        {
+                            WriteError($"  [!] Error accessing {file}\n");
+                        }
                         continue;
                     }
 
@@ -119,10 +134,24 @@ namespace Seatbelt.Commands.Windows
                         DirectoryInfo directoryInfo = new DirectoryInfo(file);
                         directorySecurity = directoryInfo.GetAccessControl();
                     }
-                    catch
+                    catch (Exception ex)
                     {
-                        // TODO: Properly process error
-                        WriteError($"  [!] Error accessing {file}\n");
+                        if (ex is FileNotFoundException || ex is SystemException)
+                        {
+                            WriteError($"  [!] Could not locate {file}\n");
+                        }
+                        else if (ex is SecurityException || ex is UnauthorizedAccessException)
+                        {
+                            WriteError($"  [!] Insufficient privileges to access {file}\n");
+                        }
+                        else if (ex is ArgumentException || ex is PathTooLongException)
+                        {
+                            WriteError($"  [!] Path \"{file}\" is an invalid format\n");
+                        }
+                        else
+                        {
+                            WriteError($"  [!] Error accessing {file}\n");
+                        }
                         continue;
                     }
 


### PR DESCRIPTION
This PR extends the `fileinfo` command to also target directories. Only a limited amount of data can be collected compared to a normal file, so I opted to create a new internal class instead of trying to modify the existing one. 

This PR also adds in more robust error handling for the command.