### PR TITLE
Fixing a minor variable overwrite

### DIFF
--- a/Seatbelt/Commands/Windows/ServicesCommand.cs
+++ b/Seatbelt/Commands/Windows/ServicesCommand.cs
@@ -91,7 +91,7 @@ namespace Seatbelt.Commands.Windows
                 }
 
 
-                serviceDll = TryGetServiceSddl(serviceName);
+                serviceSddl = TryGetServiceSddl(serviceName);
                 
 
                 yield return new ServicesDTO()


### PR DESCRIPTION
Hey guys,

I found a super simple bug in the `Services` module where the `ServiceDll` property was being overwritten by the `ServiceSddl`. I patched it up and validated on Win10 20H1.

❤️
