### PR TITLE
Adding SecureBoot command

### DIFF
--- a/Seatbelt/Commands/Windows/SecureBootCommand.cs
+++ b/Seatbelt/Commands/Windows/SecureBootCommand.cs
@@ -1,0 +1,51 @@
+﻿#if DEBUG
+using Microsoft.Win32;
+using System.Collections.Generic;
+
+
+namespace Seatbelt.Commands.Windows
+{
+    internal class SecureBootCommand : CommandBase
+    {
+        public override string Command => "SecureBoot";
+        public override string Description => "Secure Boot configuration";
+        public override CommandGroup[] Group => new[] {CommandGroup.System, CommandGroup.Remote};
+        public override bool SupportRemote => true;
+        public Runtime ThisRunTime;
+
+        public SecureBootCommand(Runtime runtime) : base(runtime)
+        {
+            ThisRunTime = runtime;
+        }
+
+        public override IEnumerable<CommandDTOBase?> Execute(string[] args)
+        {
+            var uefiSecureBootState = ThisRunTime.GetDwordValue(RegistryHive.LocalMachine, @"SYSTEM\CurrentControlSet\Control\SecureBoot\State", @"UEFISecureBootEnabled");
+            if (uefiSecureBootState == null)
+                yield break; // Exit the function and don't return anything
+
+            var policyPublisher = ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SYSTEM\CurrentControlSet\Control\SecureBoot\State", @"PolicyPublisher");
+            var policyVersion = ThisRunTime.GetStringValue(RegistryHive.LocalMachine, @"SYSTEM\CurrentControlSet\Control\SecureBoot\State", @"PolicyVersion");
+
+            yield return new SecureBootDTO(
+                    uefiSecureBootState == 1 ? true : false,
+                    policyPublisher,
+                    policyVersion
+            );
+        }
+
+        internal class SecureBootDTO : CommandDTOBase
+        {
+            public SecureBootDTO(bool enabled, string? publisher, string? version)
+            {
+                Enabled = enabled;
+                Publisher = publisher;
+                Version = version;
+            }
+            public bool Enabled { get; }
+            public string? Publisher { get; }
+            public string? Version { get; }
+        }
+    }
+}
+#endif

--- a/Seatbelt/Seatbelt.csproj
+++ b/Seatbelt/Seatbelt.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="Commands\CommandGroup.cs" />
     <Compile Include="Commands\Misc\LOLBAS.cs" />
+    <Compile Include="Commands\Windows\SecureBootCommand.cs" />
     <Compile Include="Commands\Windows\WMICommand.cs" />
     <Compile Include="Commands\Products\FileZillaCommand.cs" />
     <Compile Include="Commands\Products\KeePass.cs" />


### PR DESCRIPTION
This PR adds the `SecureBoot` command which queries the registry for information about the state and configuration of Secure Boot. It _should_ work remotely since it is just a registry check.