### PR TITLE
Functionality to exclude specific commands from group

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ Available commands (+ means remote usage is supported):
 
 Seatbelt has the following command groups: All, User, System, Slack, Chromium, Remote, Misc
 
-    You can invoke command groups with "Seatbelt.exe <group>"
+    You can invoke command groups with         "Seatbelt.exe <group>"
+    Or command groups except specific commands "Seatbelt.exe <group> -Command"
 
    "Seatbelt.exe -group=all" runs all commands
 
@@ -226,6 +227,7 @@ Examples:
     'Seatbelt.exe <Command> -full' will return complete results for a command without any filtering.
     'Seatbelt.exe "<Command> [argument]"' will pass an argument to a command that supports it (note the quotes).
     'Seatbelt.exe -group=all' will run ALL enumeration checks, can be combined with "-full".
+    'Seatbelt.exe -group=all -AuditPolicies' will run all enumeration checks EXCEPT AuditPolicies, can be combined with "-full".
     'Seatbelt.exe <Command> -computername=COMPUTER.DOMAIN.COM [-username=DOMAIN\USER -password=PASSWORD]' will run an applicable check remotely
     'Seatbelt.exe -group=remote -computername=COMPUTER.DOMAIN.COM [-username=DOMAIN\USER -password=PASSWORD]' will run remote specific checks
     'Seatbelt.exe -group=system -outputfile="C:\Temp\out.txt"' will run system checks and output to a .txt file.

--- a/Seatbelt/Runtime.cs
+++ b/Seatbelt/Runtime.cs
@@ -311,6 +311,19 @@ namespace Seatbelt
                 return false;
 
             List<CommandBase> toExecute;
+            List<CommandBase> toExclude = new List<CommandBase>();
+
+            foreach (var remainingCommand in Commands) 
+            {
+                if(remainingCommand.StartsWith("-"))
+                {
+                    var foundCommand = AllCommands.FirstOrDefault(c => c.Command.Equals(remainingCommand.Substring(1), StringComparison.InvariantCultureIgnoreCase));
+                    if (foundCommand != null)
+                    {
+                        toExclude.Add(foundCommand);
+                    }
+                }
+            }
 
             switch (command.ToLower())
             {
@@ -334,7 +347,9 @@ namespace Seatbelt
                     break;
             }
 
-            toExecute.ForEach(c =>
+            var commandsFiltered = toExecute.Where(c => !toExclude.Contains(c)).ToList();
+
+            commandsFiltered.ForEach(c =>
             {
                 ExecuteCommand(c, new string[] { });
             });

--- a/Seatbelt/Seatbelt.cs
+++ b/Seatbelt/Seatbelt.cs
@@ -122,7 +122,8 @@ namespace Seatbelt
             // List all command groupings
             var commandGroups = Enum.GetNames(typeof(CommandGroup)).ToArray();
             _outputSink.WriteHost("\n\nSeatbelt has the following command groups: " + string.Join(", ", commandGroups));
-            _outputSink.WriteHost("\n    You can invoke command groups with \"Seatbelt.exe <group>\"\n");
+            _outputSink.WriteHost("\n    You can invoke command groups with         \"Seatbelt.exe <group>\"\n");
+            _outputSink.WriteHost("\n    Or command groups except specific commands \"Seatbelt.exe <group> -Command\"\n");
 
             var sb = new StringBuilder();
             foreach (var group in commandGroups)
@@ -164,6 +165,7 @@ namespace Seatbelt
             _outputSink.WriteHost("    'Seatbelt.exe <Command> -full' will return complete results for a command without any filtering.");
             _outputSink.WriteHost("    'Seatbelt.exe \"<Command> [argument]\"' will pass an argument to a command that supports it (note the quotes).");
             _outputSink.WriteHost("    'Seatbelt.exe -group=all' will run ALL enumeration checks, can be combined with \"-full\".");
+            _outputSink.WriteHost("    'Seatbelt.exe -group=all -AuditPolicies' will run all enumeration checks EXCEPT AuditPolicies, can be combined with \"-full\".");
             _outputSink.WriteHost("    'Seatbelt.exe <Command> -computername=COMPUTER.DOMAIN.COM [-username=DOMAIN\\USER -password=PASSWORD]' will run an applicable check remotely");
             _outputSink.WriteHost("    'Seatbelt.exe -group=remote -computername=COMPUTER.DOMAIN.COM [-username=DOMAIN\\USER -password=PASSWORD]' will run remote specific checks");
             _outputSink.WriteHost("    'Seatbelt.exe -group=system -outputfile=\"C:\\Temp\\out.txt\"' will run system checks and output to a .txt file.");


### PR DESCRIPTION
Hi!

This PR adds a simple logic to exclude specified commands from being run while group syntax is used.

Syntax:

```
Seatbelt.exe -group=all -AuditPolicies
```

Will run ALL commands except to AuditPolicies.

Use case is when for some reason Seatbelt stops execution upon reaching specific command and we insist on grabbing output of entire commands group.

Hope you'll like it.