### PR TITLE
Added process details to namedpipes command

### DIFF
--- a/Seatbelt/Commands/Windows/NamedPipesCommand.cs
+++ b/Seatbelt/Commands/Windows/NamedPipesCommand.cs
@@ -12,7 +12,7 @@ namespace Seatbelt.Commands.Windows
     internal class NamedPipesCommand : CommandBase
     {
         public override string Command => "NamedPipes";
-        public override string Description => "Named pipe names and any readable ACL information.";
+        public override string Description => "Named pipe names, any readable ACL information and associated process information.";
         public override CommandGroup[] Group => new[] {CommandGroup.System};
 
         public override bool SupportRemote => false; // almost certainly not possible
@@ -42,6 +42,59 @@ namespace Seatbelt.Commands.Windows
             {
                 FileSecurity security;
                 var sddl = "";
+                int iProcessId = 0;
+                string svProcessName = "";
+                System.IntPtr hPipe = System.IntPtr.Zero;
+                bool bvRet = false;
+
+                // Try to identify ProcessID and ProcessName
+                try
+                {
+                    //Get a handle to the pipe
+                    hPipe = CreateFile(
+                        System.String.Format("\\\\.\\pipe\\{0}", namedPipe), // The name of the file or device to be created or opened.
+                        FileAccess.Read, // The requested access to the file or device.
+                        FileShare.None, // The requested sharing mode of the file or device.
+                        System.IntPtr.Zero, // Optional. A pointer to a SECURITY_ATTRIBUTES structure.
+                        FileMode.Open, // An action to take on a file or device that exists or does not exist.
+                        FileAttributes.Normal, // The file or device attributes and flags.
+                        System.IntPtr.Zero); // Optional. A valid handle to a template file with the GENERIC_READ access right.
+
+
+                    if (hPipe.ToInt64() != -1) //verify CreateFile did not return "INVALID_HANDLE_VALUE"
+                    { 
+
+                        //Retrieve the ProcessID registered for the pipe.
+                        bvRet = GetNamedPipeServerProcessId(
+                            hPipe, // A handle to an instance of a named pipe.
+                            out iProcessId); // The process identifier.
+
+                        //If GetNamedPipeServerProcessId was successful, get the process name for the returned ProcessID
+                        if (bvRet)
+                        {
+                            svProcessName = System.Diagnostics.Process.GetProcessById(iProcessId).ProcessName;
+                        }
+                        else
+                        {
+                            //GetNamedPipeServerProcessId was unsuccessful
+                            svProcessName = "Unk";
+                        }
+
+                        //Close the pipe handle
+                        CloseHandle(hPipe);
+                    }
+                    else
+                    {
+                        //CreateFile returned "INVALID_HANDLE_VALUE" or 0xffffffff.
+                        svProcessName = "Unk";
+                    }
+                }
+                catch
+                {
+                    //Catch the exception. ProcessName is set to Unk.
+                    svProcessName = "Unk";
+                }
+
                 try
                 {
                     security = File.GetAccessControl(System.String.Format("\\\\.\\pipe\\{0}", namedPipe));
@@ -57,8 +110,12 @@ namespace Seatbelt.Commands.Windows
                     yield return new NamedPipesDTO()
                     {
                         Name = namedPipe,
-                        Sddl = sddl
+                        Sddl = sddl,
                         //SecurityDescriptor = new RawSecurityDescriptor(sddl)
+
+                        OwningProcessName = svProcessName,
+                        OwningProcessPID = iProcessId
+
                     };
                 }
                 else
@@ -66,8 +123,11 @@ namespace Seatbelt.Commands.Windows
                     yield return new NamedPipesDTO()
                     {
                         Name = namedPipe,
-                        Sddl = sddl
+                        Sddl = sddl,
                         //SecurityDescriptor = null
+
+                        OwningProcessName = svProcessName,
+                        OwningProcessPID = iProcessId
                     };
                 }
             }
@@ -79,6 +139,10 @@ namespace Seatbelt.Commands.Windows
         public string Name { get; set; }
 
         public string Sddl { get; set; }
+
+        public string OwningProcessName { get; set; }
+
+        public int OwningProcessPID { get; set; }
 
         // public RawSecurityDescriptor SecurityDescriptor { get; set; }
     }
@@ -94,7 +158,7 @@ namespace Seatbelt.Commands.Windows
         {
             var dto = (NamedPipesDTO)result;
 
-            WriteLine("  \\\\.\\pipe\\{0}", dto.Name);
+            WriteLine("{0},{1},{2}", dto.OwningProcessPID.ToString(), dto.OwningProcessName, dto.Name);
             if (!dto.Sddl.Equals("ERROR"))
             {
                 //WriteLine("    Owner   : {0}", dto.SecurityDescriptor.Owner);

--- a/Seatbelt/Interop/Kernel32.cs
+++ b/Seatbelt/Interop/Kernel32.cs
@@ -51,5 +51,21 @@ namespace Seatbelt.Interop
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)]
             public string cAlternateFileName;
         }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern IntPtr CreateFile(
+         [MarshalAs(UnmanagedType.LPTStr)] string filename,
+         [MarshalAs(UnmanagedType.U4)] System.IO.FileAccess access,
+         [MarshalAs(UnmanagedType.U4)] System.IO.FileShare share,
+         IntPtr securityAttributes,
+         [MarshalAs(UnmanagedType.U4)] System.IO.FileMode creationDisposition,
+         [MarshalAs(UnmanagedType.U4)] System.IO.FileAttributes flagsAndAttributes,
+         IntPtr templateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetNamedPipeServerProcessId(
+           IntPtr hPipe,
+           out int ClientProcessId);
+
     }
 }


### PR DESCRIPTION
Just a quick addition to the named pipes to grab the associated process id with the GetNamedPipeServerProcessId API, and also the process name using System.Diagnostics.Process.GetProcessById(). Output of command is now comma-separated as 
`<pid>,<processname>,<namedpipe>`

If the process name is not retrievable, "Unk" is set as the process name. If the process id was not retrievable, "0" is displayed as the process id.