### PR TITLE
fixed up missing file in Seatbelt.csproj.

### DIFF
--- a/Seatbelt/Seatbelt.csproj
+++ b/Seatbelt/Seatbelt.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="Commands\CommandGroup.cs" />
     <Compile Include="Commands\Misc\LOLBAS.cs" />
+    <Compile Include="Commands\Products\MTPuTTYCommand.cs" />
     <Compile Include="Commands\Products\OneNoteCommand.cs" />
     <Compile Include="Commands\Windows\SecureBootCommand.cs" />
     <Compile Include="Commands\Windows\WifiProfileCommand.cs" />


### PR DESCRIPTION
There was some code in the repo for finding/dumping MTPuTTY files but it wasn't being compiled in because it was missing from Seatbelt.csproj - this PR just adds the required ref.