### PR TITLE
Remove duplicate randomizeOrder argument in SeatbeltArgumentParser.cs

### DIFF
--- a/Seatbelt/SeatbeltArgumentParser.cs
+++ b/Seatbelt/SeatbeltArgumentParser.cs
@@ -37,7 +37,6 @@ namespace Seatbelt
                     filterResults,
                     randomizeOrder,
                     quietMode,
-                    randomizeOrder,
                     delayCommands,
                     computerName,
                     userName,


### PR DESCRIPTION
Removed duplicate randomizeOrder added in #bec6fd0
