### PR TITLE
[bug] Remove a dollar sign in UserAccountControlCommand.cs

### DIFF
--- a/Seatbelt/Commands/Windows/UserAccountControlCommand.cs
+++ b/Seatbelt/Commands/Windows/UserAccountControlCommand.cs
@@ -71,7 +71,7 @@ namespace Seatbelt.Commands.Windows
                 switch (dto.ConsentPromptBehaviorAdmin)
                 {
                     case 0:
-                        WriteLine($"  {0,-30} : {1} - No prompting", "ConsentPromptBehaviorAdmin", dto.ConsentPromptBehaviorAdmin);
+                        WriteLine("  {0,-30} : {1} - No prompting", "ConsentPromptBehaviorAdmin", dto.ConsentPromptBehaviorAdmin);
                         break;
                     case 1:
                         WriteLine("  {0,-30} : {1} - PromptOnSecureDesktop", "ConsentPromptBehaviorAdmin", dto.ConsentPromptBehaviorAdmin);


### PR DESCRIPTION
Hello,
I identified a tiny bug in Seatbelt.

In `UserAccountControlCommand.cs`, the result string is not printed correctly when `dto.ConsentPromptBehaviorAdmin` is 0 due to a dollar sign.
So I just removed it and now it looks good now.

before:
- `  0                              : 1 - No prompting` is a buggy format string.

```
====== UAC ======

  0                              : 1 - No prompting
  EnableLUA (Is UAC enabled?)    : 1
  LocalAccountTokenFilterPolicy  :
  FilterAdministratorToken       :
    [*] Default Windows settings - Only the RID-500 local admin account can be used for lateral movement.

```


after:
```
====== UAC ======

  ConsentPromptBehaviorAdmin     : 0 - No prompting
  EnableLUA (Is UAC enabled?)    : 1
  LocalAccountTokenFilterPolicy  :
  FilterAdministratorToken       :
    [*] Default Windows settings - Only the RID-500 local admin account can be used for lateral movement.
```
